### PR TITLE
Add Ollama tool experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ if __name__ == "__main__":
     print(parsed_args)
 
 ```
+
+## Experiment: tool usage with Ollama
+
+The `experiments/ollama_tool_usage.py` script shows how to request a tool call using the raw generation endpoint. Start an Ollama server locally and run:
+
+```bash
+python experiments/ollama_tool_usage.py
+```
+
+The script prints the raw JSON response so you can inspect how the model attempts to invoke the tool.

--- a/experiments/ollama_tool_usage.py
+++ b/experiments/ollama_tool_usage.py
@@ -1,0 +1,51 @@
+"""Demonstrate requesting a tool call via Ollama's raw generation API.
+
+The script sends a request asking the model to call a tool named ``hello`` and
+prints the raw response returned by the server. Tool calls are not currently
+honored by the raw generation endpoint, so this is useful to inspect how the
+model attempts to respond regardless.
+"""
+
+from __future__ import annotations
+
+import json
+
+import ollama
+
+
+TOOL_SPEC = [
+    {
+        "type": "function",
+        "function": {
+            "name": "hello",
+            "description": "Print a friendly greeting",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Text to include in the greeting",
+                    }
+                },
+                "required": ["message"],
+            },
+        },
+    }
+]
+
+
+def run_experiment() -> None:
+    """Send the generation request and dump the raw response."""
+    response = ollama.generate(
+        model="llama3",
+        prompt="Use the hello tool to greet the world.",
+        tools=TOOL_SPEC,
+        tool_choice={"type": "function", "function": {"name": "hello"}},
+        stream=False,
+        raw=True,
+    )
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == "__main__":
+    run_experiment()


### PR DESCRIPTION
## Summary
- add `experiments/ollama_tool_usage.py` to demonstrate a raw generation call with a tool specification
- document the experiment in the README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'attrs')*

------
https://chatgpt.com/codex/tasks/task_e_6873ed3a02d083338555bcc47a5c0853