### PR TITLE
Improve documentation and add docstrings

### DIFF
--- a/docs/FULL_DOCUMENTATION.md
+++ b/docs/FULL_DOCUMENTATION.md
@@ -1,0 +1,33 @@
+# pyars Documentation
+
+`pyars` is a lightweight wrapper around `argparse` that lets you declare command
+line interfaces using `attrs` classes. Fields are annotated with special
+argument descriptors which control how each attribute is parsed.
+
+## Defining Arguments
+
+Decorate your class with `@arguments` to enable parsing:
+
+```python
+from pyars import arguments, positional, flag, switch, command
+
+@arguments
+class BuildArgs:
+    projects: set[str] = positional(nargs='+', help='Projects to build')
+    root: Path = flag(default='cwd')
+    verbose: bool = switch(help_suffix='verbose output')
+```
+
+Running `BuildArgs.parse_args()` returns an instance populated from
+``sys.argv``.
+
+## Argument Types
+
+* **positional** – creates a mandatory positional argument.
+* **flag** – standard option that accepts a value and may have defaults.
+* **switch** – boolean flag supporting ``--feature`` / ``--no-feature``.
+* **command** – selects a sub-command implemented by another argument
+  container.
+
+Refer to `example.py` for a full usage example.
+

--- a/example.py
+++ b/example.py
@@ -1,7 +1,10 @@
+"""Example demonstrating basic usage of :mod:`pyars`."""
+
 from pyars import *
 
 @arguments
 class BuildArguments:
+    """Arguments for the ``build`` command."""
     projects: set[str] = positional(nargs='+', help="The projects you want to use")
     root: Path = flag(extra_opts='--root-path', default='cwd', help="The root dir to use")
     verbose: bool = switch(help_suffix="verbose output")
@@ -10,11 +13,13 @@ class BuildArguments:
 
 @arguments
 class CleanArguments:
+    """Arguments for the ``clean`` command."""
     include_subdirs: bool = switch(help_suffix='Clean subdirectories as well')
     force: bool = switch(help_suffix='Force cleaning, even if up-to-date')
 
 @arguments
 class ConsoleArguments:
+    """Top-level arguments for the console application."""
     root: Path
     command: Arguments = command(
         extra={},
@@ -23,6 +28,7 @@ class ConsoleArguments:
     )
 
 def main() -> None:
+    """Entry point for running the example."""
     parsed_args = ConsoleArguments.parse_args([
         'some/root', 'build', 'proj1', 'proj2', '--verbose', '--colorize', '--root', 'my-root'
     ])

--- a/pyars/__init__.py
+++ b/pyars/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Public package interface for ``pyars``."""
+
 from pathlib import Path
 
 from .container import arguments, ArgumentContainer as Arguments

--- a/pyars/container.py
+++ b/pyars/container.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Utilities for describing command line arguments using attrs classes."""
+
 from argparse import ArgumentParser, Namespace
 from typing import Iterable, Self, Callable
 
@@ -7,14 +9,17 @@ from attrs import define, fields, Attribute, NOTHING
 
 
 class ArgumentContainer:
+    """Mix-in providing ``argparse`` integration for attrs classes."""
     @classmethod
     def new_parser(cls, *args, **kwargs) -> ArgumentParser:
+        """Return an ``ArgumentParser`` pre-configured for ``cls``."""
         parser = ArgumentParser(*args, **kwargs)
         cls.add_arguments('', parser)
         return parser
 
     @classmethod
     def get_arguments(cls) -> Iterable[tuple[Attribute, "ArgumentType"]]:
+        """Yield ``(field, argument_type)`` tuples for all attrs fields."""
         from .argument_types import ArgumentType, PositionalArgument
         for field in fields(cls):
             argument = field.default
@@ -26,11 +31,13 @@ class ArgumentContainer:
 
     @classmethod
     def add_arguments(cls, prefix: str, parser: ArgumentParser):
+        """Add options for all fields of ``cls`` to ``parser``."""
         for field, argument in cls.get_arguments():
             argument.add_argument(prefix, field, parser)
 
     @classmethod
     def namespace_to_dict(cls, prefix: str, namespace: Namespace) -> dict[str, object]:
+        """Create a kwargs dict from ``namespace`` for constructing ``cls``."""
         kwargs: dict[str, object] = {}
         for field, argument in cls.get_arguments():
             kwargs[field.name] = argument.extract(prefix, field, namespace)
@@ -38,10 +45,12 @@ class ArgumentContainer:
 
     @classmethod
     def from_namespace(cls, prefix: str, namespace: Namespace) -> Self:
+        """Instantiate ``cls`` using values extracted from ``namespace``."""
         return cls(**cls.namespace_to_dict(prefix, namespace))
 
     @classmethod
     def parse_args(cls, argv: list[str] | None = None) -> Self:
+        """Parse ``argv`` and return an instance of ``cls``."""
         parser = cls.new_parser()
         namespace = parser.parse_args(argv)
         instance = cls.from_namespace('', namespace)
@@ -49,6 +58,7 @@ class ArgumentContainer:
 
 
 def arguments(outer_cls: type | None = None, **kwargs) -> type[ArgumentContainer] | Callable:
+    """Decorate a class to become an ``ArgumentContainer``."""
     def wrapper(cls: type) -> type[ArgumentContainer]:
         cls = define(**kwargs)(cls)
         mixed_type: type[ArgumentContainer] = type(cls.__name__, (cls, ArgumentContainer), {})


### PR DESCRIPTION
## Summary
- document all public classes and methods in `pyars`
- add docstrings to the example script
- provide a new `FULL_DOCUMENTATION.md` with package usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyars')*

------
https://chatgpt.com/codex/tasks/task_e_6874f044be9c833380336a59ebb4f687