### PR TITLE
Add CLI validation for conflicting switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ if __name__ == "__main__":
     print(parsed_args)
 
 ```
+
+### Validation
+
+Providing conflicting switches raises an ``InvalidArgumentsError``:
+
+```python
+BuildArguments.parse_args(['proj', '--verbose', '--no-verbose'])
+```

--- a/docs/FULL_DOCUMENTATION.md
+++ b/docs/FULL_DOCUMENTATION.md
@@ -31,3 +31,12 @@ Running `BuildArgs.parse_args()` returns an instance populated from
 
 Refer to `example.py` for a full usage example.
 
+## Validation
+
+Containers perform a validation pass before parsing. Using mutually
+exclusive switches results in ``InvalidArgumentsError``:
+
+```python
+BuildArgs.parse_args(['proj', '--verbose', '--no-verbose'])
+```
+

--- a/pyars/__init__.py
+++ b/pyars/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .container import arguments, ArgumentContainer as Arguments
+from .container import arguments, ArgumentContainer as Arguments, InvalidArgumentsError
 from .argument_types import (
     CommandArgument as command,
     PositionalArgument as positional,
@@ -19,5 +19,6 @@ __all__ = [
     'flag',
     'switch',
     'Arguments',
+    'InvalidArgumentsError',
     'Path',
 ]

--- a/tests/test_pyars.py
+++ b/tests/test_pyars.py
@@ -1,6 +1,7 @@
 from pathlib import Path
+import pytest
 
-from pyars import arguments, positional, flag, switch, command, Arguments
+from pyars import arguments, positional, flag, switch, command, Arguments, InvalidArgumentsError
 
 
 @arguments
@@ -33,7 +34,7 @@ def test_build_parse_defaults():
     argv = ['proj1']
     parsed = BuildArguments.parse_args(argv)
     assert parsed.projects == {'proj1'}
-    assert parsed.root == 'cwd'
+    assert parsed.root == Path('cwd')
     assert parsed.verbose is False
     assert parsed.parallel == 1
     assert parsed.colorize_output is False
@@ -79,3 +80,9 @@ def test_command_clean():
     parsed = ConsoleArguments.parse_args(argv)
     assert isinstance(parsed.command, CleanArguments)
     assert parsed.command.force is True
+
+
+def test_switch_conflict():
+    argv = ['proj', '--verbose', '--no-verbose']
+    with pytest.raises(InvalidArgumentsError):
+        BuildArguments.parse_args(argv)


### PR DESCRIPTION
## Summary
- detect mutually exclusive switch usage prior to parsing
- expose `InvalidArgumentsError` in package API
- document validation behaviour
- test new validation logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fa6d088483339f10d5e221d25569