### PR TITLE
Enhance parser customization

### DIFF
--- a/docs/FULL_DOCUMENTATION.md
+++ b/docs/FULL_DOCUMENTATION.md
@@ -31,3 +31,24 @@ Running `BuildArgs.parse_args()` returns an instance populated from
 
 Refer to `example.py` for a full usage example.
 
+## Advanced Usage
+
+`ArgumentContainer.new_parser()` can be customised further by supplying
+additional `ArgumentParser` options or a callback. Extra positional or keyword
+arguments are forwarded directly to `ArgumentParser` while callbacks receive the
+fully configured parser for modification:
+
+```python
+def with_debug(parser: ArgumentParser) -> None:
+    parser.add_argument('--debug', action='store_true')
+
+parser = BuildArgs.new_parser(
+    callbacks=with_debug,
+    description='Build projects',
+)
+args = parser.parse_args(['proj', '--debug'])
+```
+
+The callback gets access to the parser instance so any additional options or
+settings remain active when parsing command lines.
+

--- a/pyars/container.py
+++ b/pyars/container.py
@@ -11,10 +11,31 @@ from attrs import define, fields, Attribute, NOTHING
 class ArgumentContainer:
     """Mix-in providing ``argparse`` integration for attrs classes."""
     @classmethod
-    def new_parser(cls, *args, **kwargs) -> ArgumentParser:
-        """Return an ``ArgumentParser`` pre-configured for ``cls``."""
+    def new_parser(
+        cls,
+        *args,
+        callbacks: Callable[[ArgumentParser], None]
+        | Iterable[Callable[[ArgumentParser], None]]
+        | None = None,
+        **kwargs,
+    ) -> ArgumentParser:
+        """Return an ``ArgumentParser`` pre-configured for ``cls``.
+
+        Additional positional and keyword arguments are forwarded directly to
+        :class:`ArgumentParser`.  ``callbacks`` may be a single callable or an
+        iterable of callables that receive the created parser to perform further
+        customization.
+        """
+
         parser = ArgumentParser(*args, **kwargs)
         cls.add_arguments('', parser)
+
+        if callbacks is not None:
+            if callable(callbacks):
+                callbacks = (callbacks,)
+            for cb in callbacks:
+                cb(parser)
+
         return parser
 
     @classmethod

--- a/tests/test_pyars.py
+++ b/tests/test_pyars.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from argparse import ArgumentParser
 
 from pyars import arguments, positional, flag, switch, command, Arguments
 
@@ -33,7 +34,7 @@ def test_build_parse_defaults():
     argv = ['proj1']
     parsed = BuildArguments.parse_args(argv)
     assert parsed.projects == {'proj1'}
-    assert parsed.root == 'cwd'
+    assert parsed.root == Path('cwd')
     assert parsed.verbose is False
     assert parsed.parallel == 1
     assert parsed.colorize_output is False
@@ -79,3 +80,17 @@ def test_command_clean():
     parsed = ConsoleArguments.parse_args(argv)
     assert isinstance(parsed.command, CleanArguments)
     assert parsed.command.force is True
+
+
+def test_new_parser_callback_and_kwargs():
+    captured: list[ArgumentParser] = []
+
+    def customize(parser: ArgumentParser) -> None:
+        captured.append(parser)
+        parser.add_argument('--extra', action='store_true')
+
+    parser = BuildArguments.new_parser(callbacks=customize, description='desc')
+    assert parser.description == 'desc'
+    namespace = parser.parse_args(['proj', '--extra'])
+    assert captured[0] is parser
+    assert namespace.extra is True


### PR DESCRIPTION
## Summary
- extend `ArgumentContainer.new_parser` with optional callbacks
- document advanced parser customization
- test parser callback and forwarded kwargs
- update expectation for default `Path`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fa6778b08333ba041e166073dde9