### PR TITLE
Update examples to use explicit imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ You can also check the `example.py` in the root of the project.
 The usage is straightforward.
 
 ```python
-from pyars import *
+from pathlib import Path
+from pyars import arguments, positional, flag, switch, command, Arguments
 
 @arguments
 class BuildArguments:

--- a/example.py
+++ b/example.py
@@ -1,6 +1,8 @@
 """Example demonstrating basic usage of :mod:`pyars`."""
 
-from pyars import *
+from pathlib import Path
+
+from pyars import arguments, positional, flag, switch, command, Arguments
 
 @arguments
 class BuildArguments:


### PR DESCRIPTION
## Summary
- use explicit imports in `example.py`
- update README snippet to mirror the code example

## Testing
- `PYTHONPATH=. pytest -q` *(fails: AssertionError in tests/test_pyars.py::test_build_parse_defaults)*

------
https://chatgpt.com/codex/tasks/task_e_6874fa0f35388333829b8ec4212a3f29