### PR TITLE
Improve safe type resolution

### DIFF
--- a/pyars/argument_types.py
+++ b/pyars/argument_types.py
@@ -9,10 +9,36 @@ values from a parsed :class:`argparse.Namespace`.
 """
 
 from pathlib import Path
-from types import GenericAlias, UnionType
-from typing import Callable
+from types import GenericAlias, SimpleNamespace, UnionType
+from typing import Callable, get_type_hints
 from argparse import ArgumentParser, Namespace
 from attrs import Attribute, NOTHING
+
+_ALLOWED_NAMES: dict[str, type] = {
+    'int': int,
+    'float': float,
+    'bool': bool,
+    'list': list,
+    'tuple': tuple,
+    'set': set,
+    'frozenset': frozenset,
+    'bytes': bytes,
+    'bytearray': bytearray,
+    'str': str,
+    'Path': Path,
+}
+
+
+def _resolve_annotation(annotation: str) -> type | Callable | None:
+    """Return a type object for ``annotation`` if allowed."""
+    if annotation in _ALLOWED_NAMES:
+        return _ALLOWED_NAMES[annotation]
+    try:
+        dummy = SimpleNamespace()
+        dummy.__annotations__ = {'v': annotation}
+        return get_type_hints(dummy, globalns=_ALLOWED_NAMES)['v']
+    except Exception:
+        return None
 
 from .container import ArgumentContainer
 
@@ -127,9 +153,8 @@ class ValueArgument(ArgumentType):
         elif not isinstance(attr.type, str):
             type_value = attr.type
         else:
-            try:
-                type_value = eval(attr.type, globals())
-            except Exception:
+            type_value = _resolve_annotation(attr.type)
+            if type_value is None:
                 type_value = self.guess_converter(attr.type)
 
         if isinstance(type_value, GenericAlias):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from pathlib import Path
+
+from pyars import arguments, positional, flag, switch
+
+
+@arguments
+class StringArgs:
+    value: 'Path'
+    count: 'int' = flag()
+    verbose: 'bool' = switch()
+
+
+def test_string_annotations_parsing():
+    argv = ['folder', '--count', '3', '--verbose']
+    parsed = StringArgs.parse_args(argv)
+    assert parsed.value == Path('folder')
+    assert parsed.count == 3
+    assert parsed.verbose is True
+
+
+@arguments
+class UnknownArgs:
+    stuff: 'Unknown'
+
+
+def test_unknown_annotation_graceful():
+    argv = ['x']
+    parsed = UnknownArgs.parse_args(argv)
+    assert parsed.stuff == 'x'
+
+
+@arguments
+class GenericArgs:
+    names: 'list[str]' = positional(nargs='+')
+
+
+def test_generic_string_annotation():
+    argv = ['a', 'b']
+    parsed = GenericArgs.parse_args(argv)
+    assert parsed.names == ['a', 'b']

--- a/tests/test_pyars.py
+++ b/tests/test_pyars.py
@@ -33,7 +33,7 @@ def test_build_parse_defaults():
     argv = ['proj1']
     parsed = BuildArguments.parse_args(argv)
     assert parsed.projects == {'proj1'}
-    assert parsed.root == 'cwd'
+    assert parsed.root == Path('cwd')
     assert parsed.verbose is False
     assert parsed.parallel == 1
     assert parsed.colorize_output is False


### PR DESCRIPTION
## Summary
- replace `eval(attr.type, globals())` with controlled annotation lookup
- handle unknown annotations gracefully
- update tests for updated default path type
- add tests for string annotations

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fa0867c48333b4df282cdb8c8b8b