### PR TITLE
Fix positional arg detection and add flag default test

### DIFF
--- a/pyars/container.py
+++ b/pyars/container.py
@@ -23,10 +23,12 @@ class ArgumentContainer:
         from .argument_types import ArgumentType, PositionalArgument
         for field in fields(cls):
             argument = field.default
-            if field.default in (NOTHING, None, ...):
+            if field.default is NOTHING or field.default is ...:
                 argument = PositionalArgument()
             if not isinstance(argument, ArgumentType):
-                raise TypeError(f'Use a argument type as a default value, not {argument}')
+                raise TypeError(
+                    f'Use a argument type as a default value, not {argument!r}'
+                )
             yield field, argument
 
     @classmethod

--- a/tests/test_pyars.py
+++ b/tests/test_pyars.py
@@ -33,7 +33,7 @@ def test_build_parse_defaults():
     argv = ['proj1']
     parsed = BuildArguments.parse_args(argv)
     assert parsed.projects == {'proj1'}
-    assert parsed.root == 'cwd'
+    assert parsed.root == Path('cwd')
     assert parsed.verbose is False
     assert parsed.parallel == 1
     assert parsed.colorize_output is False
@@ -79,3 +79,13 @@ def test_command_clean():
     parsed = ConsoleArguments.parse_args(argv)
     assert isinstance(parsed.command, CleanArguments)
     assert parsed.command.force is True
+
+
+@arguments
+class NoneDefaultArguments:
+    flag_arg: str | None = flag(default=None)
+
+
+def test_flag_default_none_optional():
+    parsed = NoneDefaultArguments.parse_args([])
+    assert parsed.flag_arg is None


### PR DESCRIPTION
## Summary
- don't treat `None` defaults as positional arguments
- update build default test to expect `Path('cwd')`
- test that `flag(default=None)` yields an optional flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874fa035ad88333a7c563628970295d