### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ if __name__ == "__main__":
 ## Contributing
 
 Install dependencies, including `attrs`, and run the test suite:
-
 ```bash
 pip install -r requirements.txt
 pytest
-=======
+```
+
 ### Validation
 
 Providing conflicting switches raises an ``InvalidArgumentsError``:


### PR DESCRIPTION
## Summary
- correct Contributing section code block in README

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: InvalidArgumentsError not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687500fdb0208333a3dde24a7bf5cd2c