### PR TITLE
Remove stray import from argument_types

### DIFF
--- a/pyars/argument_types.py
+++ b/pyars/argument_types.py
@@ -13,7 +13,6 @@ from types import GenericAlias, SimpleNamespace, UnionType
 from typing import Callable, get_type_hints
 from argparse import ArgumentParser, Namespace
 from enum import Enum
-from distutils.util import strtobool
 import os
 from attrs import Attribute, NOTHING
 


### PR DESCRIPTION
## Summary
- trim unused `strtobool` import from `pyars/argument_types.py`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: NameError: InvalidArgumentsError is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687500f41e108333b1d55fa06c2aace6