### PR TITLE
Fix lint for forward-referenced annotation test

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from pyars import arguments, positional, option, flag
 
 
+class Unknown(str):
+    """Sentinel type used to exercise forward reference handling."""
+
+
 @arguments
 class StringArgs:
     value: 'Path'


### PR DESCRIPTION
## Summary
- define a sentinel `Unknown` type in `tests/test_annotations.py` so linting does not flag the forward reference used in tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d318e4dae48333b0fff19bfff54ad2