### PR TITLE
Document option conversion semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 ```
 
 * `positional` – declare positional parameters, supporting `nargs` and value conversion.
-* `option` – add named options accepting values; pass `convert=` to transform CLI input (and defaults).
+* `option` – add named options accepting values; `convert=` runs on CLI input and defaults before `choices` are validated, so define choices using the converted values. Short-only definitions still receive an automatic `--long-name` alias, and providing a `default` automatically sets `required=False`.
 * `flag` – boolean toggles that default to `False` and become `True` when the flag is present. Short options automatically gain a `--long-name` alias derived from the attribute.
 * `command` – nest other `@arguments` containers as sub-commands.
 

--- a/docs/FULL_DOCUMENTATION.md
+++ b/docs/FULL_DOCUMENTATION.md
@@ -27,12 +27,31 @@ Running `BuildArgs.parse_args()` returns an instance populated from
 ## Argument Types
 
 * **positional** – declare positional parameters. `nargs` and `convert` let you customise arity and type conversion.
-* **option** – named options that expect a value. When no names are supplied a `--long-name` is generated automatically; short options gain a matching long alias.
+* **option** – named options that expect a value. Values pass through the option's `convert` callable before validation, so `choices` should contain the converted representation (for example, `Path` instances rather than strings). When no names are supplied a `--long-name` is generated automatically; supplying only short names still gains a long alias. Providing a `default` marks the option as optional (`required=False`) even when not specified explicitly.
 * **flag** – boolean toggles that default to ``False`` and become ``True`` when present.
 * **command** – selects a sub-command implemented by another argument
   container.
 
 Refer to `example.py` or `new-spec.py` for a full usage example.
+
+### Automatic Long Alias Example
+
+Supplying only a short option name still provides a derived long alias:
+
+```python
+@arguments
+class ServeArgs:
+    port: int = option('-p', convert=int, help='Port to bind')
+
+ServeArgs.parse_args(['--port', '8080'])
+```
+
+On the command line this enables either form:
+
+```bash
+python app.py -p 8080
+python app.py --port 8080
+```
 
 ## Advanced Usage
 


### PR DESCRIPTION
## Summary
- explain how option converters interact with choices and defaults in the documentation and README
- describe that defaults disable implicit required=True for options and document automatic long-alias behaviour
- add an example illustrating the derived long-option alias when only short names are provided

## Testing
- no tests were run (not required for documentation updates)


------
https://chatgpt.com/codex/tasks/task_e_68d547eeef148333baafaf619c1368bf